### PR TITLE
add CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.18)
+project(flash_mla_cuda LANGUAGES CXX CUDA)
+
+enable_language(C)
+enable_language(CXX)
+enable_language(CUDA)
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+   set(CMAKE_CUDA_ARCHITECTURES "80")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W0") 
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -w -g") 
+endif()
+
+if (CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w")
+endif()
+
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+set(PYTHON_VERSION ${Python_VERSION})
+
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import torch; print(torch.utils.cmake_prefix_path)"
+   OUTPUT_VARIABLE PYTORCH_CMAKE_PREFIX_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+message("PYTORCH_CMAKE_PREFIX_PATH ${PYTORCH_CMAKE_PREFIX_PATH}")
+list(APPEND CMAKE_PREFIX_PATH ${PYTORCH_CMAKE_PREFIX_PATH})
+message("CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH}")
+
+find_package(Torch REQUIRED)
+find_library(TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib")
+
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import pybind11; print(pybind11.get_cmake_dir())"
+	OUTPUT_VARIABLE pybind11_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+find_package(pybind11 REQUIRED)
+
+file(GLOB_RECURSE CSRC_SOURCES
+    "csrc/*.cu"
+)
+
+file(GLOB_RECURSE CSRC_HEADERS
+    "csrc/*.h"
+)
+
+add_library(csrc SHARED ${CSRC_SOURCES})
+set_property(TARGET csrc PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(csrc
+    PUBLIC "csrc/cutlass/include"
+    ${CSRC_HEADERS}
+)
+
+pybind11_add_module(${PROJECT_NAME} csrc/flash_api.cpp)
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${TORCH_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE 
+    csrc
+    ${TORCH_LIBRARIES}
+    ${TORCH_PYTHON_LIBRARY}
+    "-Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FlashMLA
 
+***Adapted from：*** https://github.com/deepseek-ai/FlashMLA/
+
 FlashMLA is an efficient MLA decoding kernel for Hopper GPUs, optimized for variable-length sequences serving.
 
 Currently released:
@@ -20,7 +22,7 @@ python setup.py install
 python tests/test_flash_mla.py
 ```
 
-Achieving up to 3000 GB/s in memory-bound configuration and 580 TFLOPS in computation-bound configuration on H800 SXM5, using CUDA 12.6.
+Achieving up to 300 GB/s in and 125 TFLOPS on A100 SXM5, using CUDA 12.8.
 
 ### Usage
 
@@ -52,7 +54,7 @@ FlashMLA is inspired by [FlashAttention 2&3](https://github.com/dao-AILab/flash-
 
 ```bibtex
 @misc{flashmla2025,
-      title={FlashMLA: Efficient MLA decoding kernel}, 
+      title={FlashMLA: Efficient MLA decoding kernel},
       author={Jiashi Li},
       year={2025},
       publisher = {GitHub},

--- a/csrc/flash_api.cpp
+++ b/csrc/flash_api.cpp
@@ -10,6 +10,8 @@
 #include "flash_mla.h"
 #include "static_switch.h"
 
+#define TORCH_EXTENSION_NAME flash_mla_cuda
+
 #define CHECK_DEVICE(x) TORCH_CHECK(x.is_cuda(), #x " must be on CUDA")
 #define CHECK_SHAPE(x, ...) TORCH_CHECK(x.sizes() == torch::IntArrayRef({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")


### PR DESCRIPTION
## Added CMakeLists.txt file, how to test can add Makefile file with contents:
```Makefile
NUM_JOBS = 8
CXX      = g++
CMAKE_CMD = mkdir -p build && cd build && cmake ..
FLAGS = 
DEBUG_FLAGS = $(FLAGS) -DCMAKE_BUILD_TYPE:STRING=Debug
RELEASE_FLAGS = $(FLAGS) -DCMAKE_BUILD_TYPE:STRING=Release
all : 
	$(CMAKE_CMD) $(DEBUG_FLAGS) && make -s -j$(NUM_JOBS) && cp flash_mla_cuda.cpython*.so ../tests/  && python ../tests/test_flash_mla.py
clean:
	read -r -p "This will delete the contents of build/*. Are you sure? [CRAL-C to abort] " response && rm -rf build/*
.PHONY: all run clean
```
## result:
```bash
$ run
$....
-- Found pybind11: /miniconda3/envs/tx/lib/python3.10/site-packages/pybind11/include (found version "2.13.6")
-- Configuring done
-- Generating done
-- Build files have been written to: /home/tianxin/mygit/FlashMLA/build
[ 50%] Built target csrc
[ 75%] Building CXX object CMakeFiles/flash_mla_cuda.dir/csrc/flash_api.cpp.o
[100%] Linking CXX shared module flash_mla_cuda.cpython-310-x86_64-linux-gnu.so
[100%] Built target flash_mla_cuda
b=128, s_q=1, mean_sk=4096, h_q=16, h_kv=1, d=192, dv=128, causal=True, varlen=False
out: cos_diff=1.5247754181491047e-06, RMSE=0.00013360916266193473, amax_diff=0.001011490821838379
lse: cos_diff=2.3314683517128287e-15, RMSE=6.082156786906287e-07, amax_diff=1.9073486328125e-06
0.901 ms, 6 TFLOPS, 225 GB/s
.....
```
